### PR TITLE
Upgrade sbt from 0.13.2 to 0.13.7

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.7


### PR DESCRIPTION
The version of Scala is fixed for a specific sbt release and cannot be changed. For sbt 0.13.7, this version is Scala 2.10.4., and for sbt 0.13.2, this version is Scala 2.10.3. See [sbt’s Scala version](http://www.scala-sbt.org/0.13/docs/Configuring-Scala.html#sbt%E2%80%99s+Scala+version)

In this project the file [BuildSettings.scala](https://github.com/snowplow/scalding-example-project/blob/master/project/BuildSettings.scala) has specified the Scala version to 2.10.4, but in `build.properties` the sbt's version is still `0.13.2` which is outdated, so when you run `sbt assembly` to compile this project it will still download `scala-compiler-2.10.3.jar` and use Scala 2.10.3 to compile the project. To enable compiling with Scala 2.10.4, we need to update the version of sbt in  the file `build.properties`.
